### PR TITLE
Use `CTRL_REG3_A`'s `I1_DRDY1` for data ready with `EXTI4`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,9 +331,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "lsm303dlhc-ng"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f350d2cd9ecd6c8b0b3b60a02a551575ba8fb2b3dcd57af9f033da3346b5e718"
+checksum = "31f8ed419df9fcefd46b5c3914f0e6a025cd4397ed715adb54535bdf2fec9421"
 dependencies = [
  "accelerometer",
  "bitfield-struct",
@@ -346,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "lsm303dlhc-registers"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eb4b84cdc823aa984c8f4ebc87f6134bc8d7d44a053a68655359243827d4117"
+checksum = "8ae264429f5a8b5a40be80c97602af0bd641e69724bb84cbd7d924004f75c9bc"
 dependencies = [
  "bitfield-struct",
  "defmt",

--- a/README.md
+++ b/README.md
@@ -14,7 +14,37 @@ This project covers:
 - `probe-rs` flashing and `defmt` logging.
 - Driving the user LEDs via a Timer interrupt.
 - Querying the LSM303DLHC MEMS IMU via I2C.
+    - Observing the magnetometer's `DRDY` with an `EXTI2_TSC` interrupt.
+    - Observing the accelerometer's `I1DRDY1` with an `EXTI4` interrupt.
 - Operating a USB CDC serial port for communication.
+
+## Sensor orientation
+
+The onboard LSM303DLHC's accelerometer sensor seems to be oriented in a left-handed coordinate system:
+
+- X points forward (towards the USB connectors)
+    - When pointing the USB ports downwards, the sensors reads a positive maximum on the
+      X axis.
+    - When pointing the opposite end downwards, the sensor reads a negative maximum on the X axis.
+- Y points left
+    - When pointing the left side downwards, the sensor reads a positive maximum on the Y axis.
+- Z points down
+    - When pointing the bottom side downwards, the sensor reads a positive maximum on the Z axis.
+
+The magnetometer on the other hand - pun not intended - appears to use a right-handed coordinate system :
+
+- X points backward (towards the LEDs)
+    - When pointing the USB ports towards the earth's magnetic field vector, the sensors reads a negative maximum on the
+      X axis.
+    - When pointing the opposite end towards the vector, the sensor reads a positive maximum on the X axis.
+- Y points right
+    - When pointing the right side towards the vector, the sensor reads a positive maximum on the Y axis.
+- Z points up
+    - When pointing the top side towards the vector, the sensor reads a positive maximum on the Z axis.
+
+| Accelerometer                    | Magnetometer                    |
+|----------------------------------|---------------------------------|
+| ![](docs/tikz/accelerometer.png) | ![](docs/tikz/magnetometer.png) ||
 
 ## Flashing & Running
 
@@ -83,31 +113,3 @@ I went the hard way and installed `probe-rs` from sources:
 ```shell
 cargo install probe-rs-tools --git https://github.com/probe-rs/probe-rs --locked
 ```
-
-## Sensor orientation
-
-The onboard LSM303DLHC's accelerometer sensor seems to be oriented in a left-handed coordinate system:
-
-- X points forward (towards the USB connectors)
-    - When pointing the USB ports downwards, the sensors reads a positive maximum on the
-      X axis.
-    - When pointing the opposite end downwards, the sensor reads a negative maximum on the X axis.
-- Y points left
-    - When pointing the left side downwards, the sensor reads a positive maximum on the Y axis.
-- Z points down
-    - When pointing the bottom side downwards, the sensor reads a positive maximum on the Z axis.
-
-The magnetometer on the other hand - pun not intended - appears to use a right-handed coordinate system :
-
-- X points backward (towards the LEDs)
-    - When pointing the USB ports towards the earth's magnetic field vector, the sensors reads a negative maximum on the
-      X axis.
-    - When pointing the opposite end towards the vector, the sensor reads a positive maximum on the X axis.
-- Y points right
-    - When pointing the right side towards the vector, the sensor reads a positive maximum on the Y axis.
-- Z points up
-    - When pointing the top side towards the vector, the sensor reads a positive maximum on the Z axis.
-
-| Accelerometer                    | Magnetometer                    |
-|----------------------------------|---------------------------------|
-| ![](docs/tikz/accelerometer.png) | ![](docs/tikz/magnetometer.png) ||

--- a/bins/led_roulette/Cargo.toml
+++ b/bins/led_roulette/Cargo.toml
@@ -16,7 +16,7 @@ cortex-m-semihosting = "0.5.0"
 critical-section = "1.1.2"
 defmt = "0.3.8"
 defmt-rtt = "0.4.1"
-lsm303dlhc-ng = { version = "0.3.2", features = ["defmt", "accelerometer"] }
+lsm303dlhc-ng = { version = "0.3.3", features = ["defmt", "accelerometer"] }
 lsm303dlhc-registers = { version = "0.1.1", features = ["defmt"] }
 micromath = "2.1.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }

--- a/bins/led_roulette/src/compass.rs
+++ b/bins/led_roulette/src/compass.rs
@@ -101,6 +101,9 @@ impl Compass {
                 .with_fth(3)
             // TODO: This FTH value now controls WHEN the system will lock up. Higher number, later freeze.
             //      This seems to indicate that the interrupt works, but our handling is incorrect.
+            //      In i1wtm enabled mode (with overrun disabled), the system freezes up after the configured watermarks.
+            //      In i1overrun mode (with watermark disabled), the system freezes up at a much later point in time,
+            //      that the FIFO is indeed written full, and then the interrupt occurs.
         })?;
         self.lsm303dlhc.modify_register(|reg: ControlRegister5A| {
             reg

--- a/bins/led_roulette/src/compass.rs
+++ b/bins/led_roulette/src/compass.rs
@@ -90,26 +90,21 @@ impl Compass {
     pub fn interrupt(&mut self) -> Result<(), i2c::Error> {
         self.lsm303dlhc.modify_register(|reg: ControlRegister3A| {
             reg
-                .with_i1drdy1(false)
+                .with_i1drdy1(true)
                 .with_i1drdy2(false)
-                .with_i1overrun(true) // FIFO overrun interrupt on INT1
-                .with_i1wtm(true) // FIFO watermark interrupt on INT1
+                .with_i1overrun(false)
+                .with_i1wtm(false)
         })?;
         self.lsm303dlhc.modify_register(|reg: FifoControlRegisterA| {
-            reg.with_fifo_mode(FifoMode::Stream)
+            reg.with_fifo_mode(FifoMode::Bypass)
                 .with_trigger_on_int2(false)
-                .with_fth(3)
-            // TODO: This FTH value now controls WHEN the system will lock up. Higher number, later freeze.
-            //      This seems to indicate that the interrupt works, but our handling is incorrect.
-            //      In i1wtm enabled mode (with overrun disabled), the system freezes up after the configured watermarks.
-            //      In i1overrun mode (with watermark disabled), the system freezes up at a much later point in time,
-            //      that the FIFO is indeed written full, and then the interrupt occurs.
+                .with_fth(0)
         })?;
         self.lsm303dlhc.modify_register(|reg: ControlRegister5A| {
             reg
                 .with_lir_int1(false)
                 .with_lir_int2(false)
-                .with_fifo_enable(true)
+                .with_fifo_enable(false)
         })?;
         self.lsm303dlhc.modify_register(|reg: ControlRegister6A| {
             reg

--- a/bins/led_roulette/src/compass.rs
+++ b/bins/led_roulette/src/compass.rs
@@ -4,7 +4,7 @@
 use accelerometer::{Accelerometer, RawAccelerometer};
 use accelerometer::vector::{F32x3, I16x3};
 use lsm303dlhc_ng::MagOdr;
-use lsm303dlhc_registers::accel::{AccelOdr, ControlRegister3A, ControlRegister4A, ControlRegister6A};
+use lsm303dlhc_registers::accel::{AccelOdr, ControlRegister3A, ControlRegister5A, ControlRegister6A, FifoControlRegisterA, FifoMode};
 use lsm303dlhc_registers::mag::StatusRegisterM;
 use stm32f3xx_hal::gpio;
 use stm32f3xx_hal::gpio::{gpiob, OpenDrain};
@@ -92,18 +92,28 @@ impl Compass {
             reg
                 .with_i1drdy1(false)
                 .with_i1drdy2(false)
+                .with_i1overrun(true) // FIFO overrun interrupt on INT1
+                .with_i1wtm(true) // FIFO watermark interrupt on INT1
         })?;
-        self.lsm303dlhc.modify_register(|reg: ControlRegister4A| {
-            reg.with_block_data_update(false)
+        self.lsm303dlhc.modify_register(|reg: FifoControlRegisterA| {
+            reg.with_fifo_mode(FifoMode::Stream)
+                .with_trigger_on_int2(false)
+                .with_fth(3)
+            // TODO: This FTH value now controls WHEN the system will lock up. Higher number, later freeze.
+            //      This seems to indicate that the interrupt works, but our handling is incorrect.
+        })?;
+        self.lsm303dlhc.modify_register(|reg: ControlRegister5A| {
+            reg
+                .with_lir_int1(false)
+                .with_lir_int2(false)
+                .with_fifo_enable(true)
         })?;
         self.lsm303dlhc.modify_register(|reg: ControlRegister6A| {
-            reg.with_i2int1(false)
-                .with_i2int2(false)
-                .with_boot_i1(false)
-                .with_i2click_en(false)
+            reg
+                .with_i2int1(false)
                 .with_p2_active(false)
-                .with_active_low(false)
-        })
+        })?;
+        Ok(())
     }
 
     /// Consume the Compass and return the underlying Lsm303dhlc

--- a/bins/led_roulette/src/main.rs
+++ b/bins/led_roulette/src/main.rs
@@ -135,6 +135,8 @@ fn main() -> ! {
     pe4.trigger_on_edge(&mut dp.EXTI, Edge::Rising);
     pe4.enable_interrupt(&mut dp.EXTI);
     let mems_int1_interrupt = pe4.interrupt();
+
+    critical_section::with(|cs| *PE4_INT.borrow(cs).borrow_mut() = Some(pe4));
     unsafe { NVIC::unmask(mems_int1_interrupt) };
 
     // F3 Discovery board has a pull-up resistor on the D+ line.
@@ -426,7 +428,8 @@ fn EXTI2_TSC() {
         {
             MAGNETOMETER_READY.store(true, Ordering::Release);
             pin.clear_interrupt();
-            defmt::debug!("EXTI2 fired");
+        } else {
+            defmt::error!("PE2_INT not set up");
         }
     });
 }
@@ -444,7 +447,8 @@ fn EXTI4() {
         {
             ACCELEROMETER_READY.store(true, Ordering::Release);
             pin.clear_interrupt();
-            defmt::warn!("EXTI4 fired");
+        } else {
+            defmt::error!("PE4_INT not set up");
         }
     });
 }

--- a/bins/led_roulette/src/main.rs
+++ b/bins/led_roulette/src/main.rs
@@ -199,7 +199,7 @@ fn main() -> ! {
             for i in 0..1 {
                 match compass.accel_raw() {
                     Ok(value) => {
-                        defmt::info!("Received accelerometer data: {}, {}, {}", value.x, value.y, value.z)
+                        defmt::warn!("Received accelerometer data: {}, {}, {}", value.x, value.y, value.z)
                     }
                     Err(_) => { defmt::error!("Failed to read accelerometer data") }
                 }

--- a/bins/led_roulette/src/main.rs
+++ b/bins/led_roulette/src/main.rs
@@ -105,10 +105,7 @@ fn main() -> ! {
 
     // Configure a timer to generate interrupts.
     let mut timer = Timer::new(dp.TIM2, clocks, &mut rcc.apb1);
-
-    unsafe {
-        NVIC::unmask(timer.interrupt());
-    }
+    let timer_interrupt = timer.interrupt();
 
     timer.enable_interrupt(timer::Event::Update);
     timer.start(5.milliseconds());
@@ -117,6 +114,10 @@ fn main() -> ! {
     critical_section::with(|cs| {
         TIMER.replace(cs, Some(timer));
     });
+
+    unsafe {
+        NVIC::unmask(timer_interrupt);
+    }
 
     // Configure PE2 as interrupt source for the LSM303DLHC's DRDY line.
     let mut pe2 = gpioe.pe2.into_pull_up_input(&mut gpioe.moder, &mut gpioe.pupdr);


### PR DESCRIPTION
This sets up the accelerometer's `I1_DRDY1` to fire an interrupt observed on `PE4` via `EXTI4` interrupt.