### PR TITLE
Add corncobs encoding

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     rev: v1.0
     hooks:
       - id: fmt
-      - id: cargo-check
+      # - id: cargo-check
       - id: clippy
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "corncobs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9236877021b66ad90f833d8a73a7acb702b985b64c5986682d9f1f1a184f0fb"
+
+[[package]]
 name = "cortex-m"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +590,7 @@ name = "stm32f3disco-led-roulette"
 version = "0.1.0"
 dependencies = [
  "accelerometer",
+ "corncobs",
  "cortex-m",
  "cortex-m-rt",
  "cortex-m-semihosting",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 
 [dependencies]
 accelerometer = "0.12.0"
+corncobs = "0.1.3"
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.3"
 cortex-m-semihosting = "0.5.0"

--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 
 fn main() {
     // Fetch git commit.
-    if let Ok(output) = Command::new("git").args(&["rev-parse", "HEAD"]).output() {
+    if let Ok(output) = Command::new("git").args(["rev-parse", "HEAD"]).output() {
         let git_hash = String::from_utf8(output.stdout).unwrap();
         println!("cargo:rustc-env=SERIAL={}", git_hash);
     } else {

--- a/src/compass.rs
+++ b/src/compass.rs
@@ -1,8 +1,8 @@
 // Original source: https://github.com/rubberduck203/stm32f3-discovery/blob/45c7f1b4375d6c4b7ab4f70d5699323d6feb98cc/src/compass.rs
 // SPDX-License-Identifier: MIT or Apache-2.0
 
-use accelerometer::{Accelerometer, RawAccelerometer};
 use accelerometer::vector::{F32x3, I16x3};
+use accelerometer::{Accelerometer, RawAccelerometer};
 use lsm303dlhc_ng::MagOdr;
 use lsm303dlhc_registers::accel::AccelOdr;
 use lsm303dlhc_registers::mag::StatusRegisterM;


### PR DESCRIPTION
This adds [Consistent Overhead Byte Stuffing (COBS)](https://en.wikipedia.org/wiki/Consistent_Overhead_Byte_Stuffing) encoding via [corncobs](https://docs.rs/corncobs/latest/corncobs/) as part of #4. Tandem to https://github.com/sunsided/serial-sensors/pull/3.

This stuffs the payload with an overhead byte `0x03` (`0b00000011`) and terminates the payload with a `0x00` delimiter:

![image](https://github.com/sunsided/stm32f3disco-rust/assets/495335/c0d0b30c-8bb4-4e5e-a31e-d93629a50026)
