### PR TITLE
Use serial-sensors-proto for communication

### DIFF
--- a/.idea/stm32f3discovery.iml
+++ b/.idea/stm32f3discovery.iml
@@ -5,6 +5,7 @@
       <sourceFolder url="file://$MODULE_DIR$/bins/led_roulette/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/crates/led_roulette_aux/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/crates/stm32f3_discovery/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
 
 [[package]]
+name = "bincode"
+version = "2.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f11ea1a0346b94ef188834a65c068a03aec181c94896d481d7a0a40d85b0ce95"
+dependencies = [
+ "bincode_derive",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30759b3b99a1b802a7a3aa21c85c3ded5c28e1c83170d82d70f08bbf7f3e4c"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bitfield"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +186,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
+ "strsim",
  "syn 2.0.68",
 ]
 
@@ -551,6 +570,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
+name = "serial-sensors-proto"
+version = "0.1.0-alpha.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba30c5e374778da10fedd7f8930722d641b6ac255492ecc7a38c2587cd047aa"
+dependencies = [
+ "bincode",
+ "corncobs",
+ "serial-sensors-proto-derive",
+]
+
+[[package]]
+name = "serial-sensors-proto-derive"
+version = "0.1.0-alpha.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c4663f4054e41071b49b2bb62c5d956087f851292b42ccc17c03a34d4f96698"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
+]
+
+[[package]]
 name = "slice-group-by"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,7 +632,6 @@ name = "stm32f3disco-led-roulette"
 version = "0.1.0"
 dependencies = [
  "accelerometer",
- "corncobs",
  "cortex-m",
  "cortex-m-rt",
  "cortex-m-semihosting",
@@ -601,6 +642,7 @@ dependencies = [
  "lsm303dlhc-registers",
  "micromath 2.1.0",
  "panic-probe",
+ "serial-sensors-proto",
  "stm32-usbd",
  "stm32f3xx-hal",
  "switch-hal",
@@ -632,6 +674,12 @@ dependencies = [
  "stm32f3",
  "void",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "switch-hal"
@@ -730,6 +778,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "virtue"
+version = "0.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcc60c0624df774c82a0ef104151231d37da4962957d691c011c852b2473314"
 
 [[package]]
 name = "void"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2021"
 
 [dependencies]
 accelerometer = "0.12.0"
-corncobs = "0.1.3"
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.3"
 cortex-m-semihosting = "0.5.0"
@@ -21,6 +20,7 @@ lsm303dlhc-ng = { version = "0.3.4", features = ["defmt", "accelerometer"] }
 lsm303dlhc-registers = { version = "0.1.3", features = ["defmt"] }
 micromath = "2.1.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
+serial-sensors-proto = "0.1.0-alpha.2"
 stm32-usbd = "0.7.0"
 # See https://github.com/stm32-rs/stm32f3xx-hal/pull/366
 stm32f3xx-hal = { git = "https://github.com/sunsided/stm32f3xx-hal", branch = "feature/stm32-usbd-0.7.0", version = "0.10.0", features = ["stm32f303xc", "usb", "defmt"] }


### PR DESCRIPTION
Uses [`serial-sensors-proto`](https://github.com/sunsided/serial-sensors-proto) as a wire format for sensor data on the sending end of https://github.com/sunsided/serial-sensors/pull/4.

Closes #4 